### PR TITLE
Expand Response parsing

### DIFF
--- a/integration_test/test_data/handler/utils.go
+++ b/integration_test/test_data/handler/utils.go
@@ -1,0 +1,12 @@
+package handler
+
+// live is the liveness handler.
+// @Success 200 "live endpoint"
+// @Router  /live [get]
+func live() {}
+
+// pushUpdate inserts a new update.
+// @Accept  multipart/form-data
+// @Success 201 {string} string
+// @Router  /updates [post]
+func update() {}

--- a/integration_test/test_data/spec/actual.json
+++ b/integration_test/test_data/spec/actual.json
@@ -24,6 +24,15 @@
     }
   ],
   "paths": {
+    "/live": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "live endpoint"
+          }
+        }
+      }
+    },
     "/restaurants": {
       "get": {
         "responses": {
@@ -88,6 +97,22 @@
             }
           }
         ]
+      }
+    },
+    "/updates": {
+      "post": {
+        "responses": {
+          "201": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
       }
     },
     "/user": {

--- a/integration_test/test_data/spec/expected.json
+++ b/integration_test/test_data/spec/expected.json
@@ -24,6 +24,15 @@
     }
   ],
   "paths": {
+    "/live": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "live endpoint"
+          }
+        }
+      }
+    },
     "/restaurants": {
       "get": {
         "responses": {
@@ -88,6 +97,22 @@
             }
           }
         ]
+      }
+    },
+    "/updates": {
+      "post": {
+        "responses": {
+          "201": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
       }
     },
     "/user": {

--- a/parser/utils/type_utils.go
+++ b/parser/utils/type_utils.go
@@ -170,3 +170,7 @@ func GenSchemaObjectID(pkgName, typeName string, withoutPkg bool) string {
 func ReplaceBackslash(origin string) string {
 	return strings.ReplaceAll(origin, "\\", "/")
 }
+
+func IsValidHTTPStatusCode(statusCode int) bool {
+	return statusCode < 600 && statusCode > 99
+}


### PR DESCRIPTION
* Added parse capabilities of Responses with no content and with content of simple json Types (string, int, etc.)
* Added tests for the previous cases.

The parsing is based off [swag](https://github.com/swaggo/swag) comments, possibly in a future would be better if instead of parsing directly simple types it's added parsing for @Produce comment to know the kind of content is returned