### PR TITLE
Feature - hide refs in custom Data types

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -34,6 +34,7 @@ func action(c *cli.Context) error {
 		args.modulePath,
 		args.mainFilePath,
 		args.handlerPath,
+		args.banStrings,
 		args.debug,
 		args.strict,
 		args.schemaWithoutPkg,

--- a/app/args.go
+++ b/app/args.go
@@ -9,6 +9,7 @@ type args struct {
 	mainFilePath     string
 	handlerPath      string
 	output           string
+	banStrings       []string
 	debug            bool
 	strict           bool
 	schemaWithoutPkg bool
@@ -22,6 +23,7 @@ func LoadArgs(c *cli.Context) *args {
 		mainFilePath:     c.GlobalString("main-file-path"),
 		handlerPath:      c.GlobalString("handler-path"),
 		output:           c.GlobalString("output"),
+		banStrings:       c.GlobalStringSlice("hide-refs"),
 		debug:            c.GlobalBool("debug"),
 		strict:           c.GlobalBool("strict"),
 		schemaWithoutPkg: c.GlobalBool("schema-without-pkg"),
@@ -49,6 +51,11 @@ var flags = []cli.Flag{
 		Name:  "output",
 		Value: "oas.json",
 		Usage: "output file",
+	},
+	cli.StringSliceFlag{
+		Name:  "hide-refs",
+		Value: nil,
+		Usage: "Hide refs prefixes in custom types",
 	},
 	cli.BoolFlag{
 		Name:  "debug",

--- a/integration_test/app_test.go
+++ b/integration_test/app_test.go
@@ -13,7 +13,7 @@ import (
 
 // Characterisation test for the refactoring
 func Test_ShouldGenerateExpectedSpec(t *testing.T) {
-	if err := createSpecFile(); err != nil {
+	if err := createSpecFile(nil); err != nil {
 		panic(fmt.Sprintf("could not run app - Error %s", err.Error()))
 	}
 	actual := LoadJSONAsString("test_data/spec/actual.json")
@@ -21,6 +21,16 @@ func Test_ShouldGenerateExpectedSpec(t *testing.T) {
 	assert.Equal(t, LoadJSONAsString("test_data/spec/expected.json"), actual)
 }
 
+func Test_ShouldGenerateExpectedSpecHideRef(t *testing.T) {
+	banStrings := []string{"github.com.parvez3019.go-swagger3."}
+	if err := createSpecFile(banStrings); err != nil {
+		panic(fmt.Sprintf("could not run app - Error %s", err.Error()))
+	}
+	actual := LoadJSONAsString("test_data/spec/actual.json")
+	actual += "\n" // append new line for test
+	assert.Equal(t, LoadJSONAsString("test_data/spec/expectedHidenRef.json"), actual)
+
+}
 func LoadJSONAsString(path string) string {
 	file, err := os.Open(path)
 	if err != nil {
@@ -30,12 +40,13 @@ func LoadJSONAsString(path string) string {
 	return string(content)
 }
 
-func createSpecFile() error {
+func createSpecFile(banStrings []string) error {
+
 	p, err := parser.NewParser(
 		"test_data",
 		"test_data/server/main.go",
 		"",
-		nil,
+		banStrings,
 		false,
 		false,
 		false,

--- a/integration_test/app_test.go
+++ b/integration_test/app_test.go
@@ -2,12 +2,13 @@ package integration_test
 
 import (
 	"fmt"
-	"github.com/parvez3019/go-swagger3/parser"
-	"github.com/parvez3019/go-swagger3/writer"
-	"github.com/stretchr/testify/assert"
 	"io/ioutil"
 	"os"
 	"testing"
+
+	"github.com/parvez3019/go-swagger3/parser"
+	"github.com/parvez3019/go-swagger3/writer"
+	"github.com/stretchr/testify/assert"
 )
 
 // Characterisation test for the refactoring
@@ -34,6 +35,7 @@ func createSpecFile() error {
 		"test_data",
 		"test_data/server/main.go",
 		"",
+		nil,
 		false,
 		false,
 		false,

--- a/integration_test/test_data/spec/expectedHidenRef.json
+++ b/integration_test/test_data/spec/expectedHidenRef.json
@@ -1,0 +1,466 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "User API",
+    "description": "Restaurants API documentation",
+    "contact": {
+      "name": "Restaurants API Support",
+      "email": "parvez.hassan@olx.com"
+    },
+    "license": {
+      "name": "MIT",
+      "url": "https://en.wikipedia.org/wiki/MIT_License"
+    },
+    "version": "1.0"
+  },
+  "servers": [
+    {
+      "url": "localhost:8080",
+      "description": " Server 1"
+    },
+    {
+      "url": "localhost:8081",
+      "description": " Server 2"
+    }
+  ],
+  "paths": {
+    "/live": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "live endpoint"
+          }
+        }
+      }
+    },
+    "/restaurants": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/model.GetRestaurantsResponse"
+                }
+              }
+            }
+          }
+        },
+        "summary": "Get restaurants list",
+        "description": " Returns a list of restaurants based on filter request",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Client-Version"
+          },
+          {
+            "$ref": "#/components/parameters/Client-Language"
+          },
+          {
+            "$ref": "#/components/parameters/Client-Platform"
+          },
+          {
+            "name": "count",
+            "in": "query",
+            "description": "count of restaurants",
+            "schema": {
+              "type": "integer",
+              "format": "int64",
+              "description": "count of restaurants"
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "description": "offset limit count",
+            "schema": {
+              "type": "integer",
+              "format": "int64",
+              "description": "offset limit count"
+            }
+          },
+          {
+            "name": "order_by",
+            "in": "query",
+            "description": "order restaurants list",
+            "schema": {
+              "$ref": "#/components/schemas/OrderByEnum"
+            }
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "description": "In json format",
+            "schema": {
+              "type": "github.com.parvez3019.go-swagger3.model.Filter",
+              "$ref": "#/components/schemas/model.Filter"
+            }
+          }
+        ]
+      }
+    },
+    "/updates": {
+      "post": {
+        "responses": {
+          "201": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/user": {
+      "post": {
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/model.CreateUserResponse"
+                }
+              }
+            }
+          }
+        },
+        "summary": "Create User",
+        "description": " Creates \u0026 Returns an User based on the request",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Client-Version"
+          },
+          {
+            "$ref": "#/components/parameters/Client-Language"
+          },
+          {
+            "$ref": "#/components/parameters/Client-Platform"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/model.CreateUserRequest"
+              }
+            }
+          },
+          "required": true
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "CreateUserRequest": {
+        "type": "object",
+        "properties": {
+          "first_name": {
+            "type": "string"
+          },
+          "last_name": {
+            "type": "string"
+          },
+          "age": {
+            "type": "integer"
+          },
+          "email_id": {
+            "type": "string"
+          },
+          "user_name": {
+            "type": "string"
+          },
+          "password": {
+            "type": "string"
+          },
+          "roles": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "CreateUserResponse": {
+        "type": "object",
+        "properties": {
+          "user_id": {
+            "type": "string"
+          }
+        }
+      },
+      "Filter": {
+        "type": "object",
+        "properties": {
+          "rating": {
+            "type": "integer"
+          },
+          "type": {
+            "type": "string"
+          },
+          "distance": {
+            "type": "integer"
+          },
+          "district_code": {
+            "type": "string"
+          }
+        }
+      },
+      "GetRestaurantsResponse": {
+        "type": "object",
+        "properties": {
+          "restaurants": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "city": {
+                  "type": "string"
+                },
+                "rating": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string"
+                },
+                "menus": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "Headers": {
+        "type": "object",
+        "properties": {
+          "Client-Version": {
+            "type": "string",
+            "description": "Client Version"
+          },
+          "Client-Language": {
+            "$ref": "#/components/schemas/LanguageEnum"
+          },
+          "Client-Platform": {
+            "type": "string",
+            "description": "Available values : android, ios, web",
+            "example": "android"
+          }
+        }
+      },
+      "LanguageEnum": {
+        "type": "string",
+        "example": "en-in",
+        "enum": [
+          "en-in",
+          "en-id",
+          "id",
+          "en-mx",
+          "es-mx",
+          "en-cl",
+          "es-cl",
+          "en-ng",
+          "en-pk",
+          "en-tr",
+          "tr"
+        ]
+      },
+      "Menu": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        }
+      },
+      "OrderByEnum": {
+        "type": "string",
+        "example": "popular",
+        "enum": [
+          "nearest",
+          "popular",
+          "new",
+          "highest-rated"
+        ]
+      },
+      "Restaurant": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "city": {
+            "type": "string"
+          },
+          "rating": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "menus": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      },
+      "model.CreateUserRequest": {
+        "type": "object",
+        "properties": {
+          "first_name": {
+            "type": "string"
+          },
+          "last_name": {
+            "type": "string"
+          },
+          "age": {
+            "type": "integer"
+          },
+          "email_id": {
+            "type": "string"
+          },
+          "user_name": {
+            "type": "string"
+          },
+          "password": {
+            "type": "string"
+          },
+          "roles": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "model.CreateUserResponse": {
+        "type": "object",
+        "properties": {
+          "user_id": {
+            "type": "string"
+          }
+        }
+      },
+      "model.Filter": {
+        "type": "object",
+        "properties": {
+          "rating": {
+            "type": "integer"
+          },
+          "type": {
+            "type": "string"
+          },
+          "distance": {
+            "type": "integer"
+          },
+          "district_code": {
+            "type": "string"
+          }
+        }
+      },
+      "model.GetRestaurantsResponse": {
+        "type": "object",
+        "properties": {
+          "restaurants": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "city": {
+                  "type": "string"
+                },
+                "rating": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string"
+                },
+                "menus": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "securitySchemes": {
+      "AuthorizationHeader": {
+        "type": "http",
+        "description": "Input your token",
+        "scheme": "bearer"
+      }
+    },
+    "parameters": {
+      "Client-Language": {
+        "name": "Client-Language",
+        "in": "header",
+        "schema": {
+          "$ref": "#/components/schemas/LanguageEnum"
+        }
+      },
+      "Client-Platform": {
+        "name": "Client-Platform",
+        "in": "header",
+        "description": "Available values : android, ios, web",
+        "example": "android",
+        "schema": {
+          "type": "string",
+          "description": "Available values : android, ios, web",
+          "example": "android"
+        }
+      },
+      "Client-Version": {
+        "name": "Client-Version",
+        "in": "header",
+        "description": "Client Version",
+        "schema": {
+          "type": "string",
+          "description": "Client Version"
+        }
+      }
+    }
+  },
+  "security": [
+    {
+      "AuthorizationHeader": [
+        "read",
+        "write"
+      ]
+    }
+  ]
+}

--- a/parser/apis/parser.go
+++ b/parser/apis/parser.go
@@ -5,6 +5,7 @@ import (
 	"github.com/parvez3019/go-swagger3/parser/model"
 	"github.com/parvez3019/go-swagger3/parser/operations"
 	"github.com/parvez3019/go-swagger3/parser/schema"
+	"github.com/parvez3019/go-swagger3/parser/utils"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -18,14 +19,17 @@ type parser struct {
 	model.Utils
 	schemaParser    schema.Parser
 	operationParser operations.Parser
+
+	masker utils.Masker
 }
 
-func NewParser(utils model.Utils, api *oas.OpenAPIObject, schemaParser schema.Parser) Parser {
+func NewParser(utils model.Utils, api *oas.OpenAPIObject, schemaParser schema.Parser, masker *utils.Masker) Parser {
 	return &parser{
 		Utils:           utils,
 		OpenAPI:         api,
 		schemaParser:    schemaParser,
-		operationParser: operations.NewParser(utils, api, schemaParser),
+		operationParser: operations.NewParser(utils, api, schemaParser, masker),
+		masker:          *masker,
 	}
 }
 
@@ -49,4 +53,3 @@ func (p *parser) Parse() error {
 
 	return p.parsePaths()
 }
-

--- a/parser/operations/param.go
+++ b/parser/operations/param.go
@@ -2,11 +2,12 @@ package operations
 
 import (
 	"fmt"
+	"regexp"
+	"strings"
+
 	"github.com/iancoleman/orderedmap"
 	oas "github.com/parvez3019/go-swagger3/openApi3Schema"
 	"github.com/parvez3019/go-swagger3/parser/utils"
-	"regexp"
-	"strings"
 )
 
 func (p *parser) parseParamComment(pkgPath, pkgName string, operation *oas.OperationObject, comment string) error {
@@ -60,7 +61,7 @@ func (p *parser) parseGoBasicTypeOrStructType(pkgPath string, pkgName string, op
 		operation.RequestBody.Content[oas.ContentTypeJson] = &oas.MediaTypeObject{Schema: oas.SchemaObject{Type: "string"}}
 		return nil
 	}
-	operation.RequestBody.Content[oas.ContentTypeJson] = &oas.MediaTypeObject{Schema: oas.SchemaObject{Ref: utils.AddSchemaRefLinkPrefix(typeName)}}
+	operation.RequestBody.Content[oas.ContentTypeJson] = &oas.MediaTypeObject{Schema: oas.SchemaObject{Ref: p.masker.AddSchemaRefLinkPrefix(typeName)}}
 	return nil
 }
 
@@ -121,7 +122,7 @@ func (p *parser) appendModelSchemaRef(pkgPath string, pkgName string, operation 
 		return err
 	}
 	parameterObject.Schema = &oas.SchemaObject{
-		Ref:  utils.AddSchemaRefLinkPrefix(typeName),
+		Ref:  p.masker.AddSchemaRefLinkPrefix(typeName),
 		Type: typeName,
 	}
 	operation.Parameters = append(operation.Parameters, parameterObject)
@@ -132,7 +133,7 @@ func (p *parser) appendEnumParamRef(goType string, parameterObject oas.Parameter
 	if strings.Contains(goType, "model.") {
 		goType = strings.Replace(goType, "model.", "", -1)
 	}
-	parameterObject.Schema = &oas.SchemaObject{Ref: utils.AddSchemaRefLinkPrefix(goType)}
+	parameterObject.Schema = &oas.SchemaObject{Ref: p.masker.AddSchemaRefLinkPrefix(goType)}
 	operation.Parameters = append(operation.Parameters, parameterObject)
 }
 

--- a/parser/operations/parser.go
+++ b/parser/operations/parser.go
@@ -1,11 +1,13 @@
 package operations
 
 import (
+	"go/ast"
+	"strings"
+
 	. "github.com/parvez3019/go-swagger3/openApi3Schema"
 	"github.com/parvez3019/go-swagger3/parser/model"
 	"github.com/parvez3019/go-swagger3/parser/schema"
-	"go/ast"
-	"strings"
+	"github.com/parvez3019/go-swagger3/parser/utils"
 )
 
 type Parser interface {
@@ -17,13 +19,16 @@ type parser struct {
 
 	model.Utils
 	schema.Parser
+
+	masker *utils.Masker
 }
 
-func NewParser(utils model.Utils, api *OpenAPIObject, schemaParser schema.Parser) Parser {
+func NewParser(utils model.Utils, api *OpenAPIObject, schemaParser schema.Parser, masker *utils.Masker) Parser {
 	return &parser{
 		Utils:   utils,
 		OpenAPI: api,
 		Parser:  schemaParser,
+		masker:  masker,
 	}
 }
 

--- a/parser/operations/response.go
+++ b/parser/operations/response.go
@@ -86,7 +86,7 @@ func (p *parser) complexResponseObject(pkgPath, pkgName, typ string, responseObj
 			}
 		} else {
 			s = oas.SchemaObject{
-				Ref: utils.AddSchemaRefLinkPrefix(typeName),
+				Ref: p.masker.AddSchemaRefLinkPrefix(typeName),
 			}
 		}
 
@@ -116,7 +116,7 @@ func (p *parser) complexResponseObject(pkgPath, pkgName, typ string, responseObj
 		} else {
 			responseObject.Content[oas.ContentTypeJson] = &oas.MediaTypeObject{
 				Schema: oas.SchemaObject{
-					Ref: utils.AddSchemaRefLinkPrefix(typeName),
+					Ref: p.masker.AddSchemaRefLinkPrefix(typeName),
 				},
 			}
 		}

--- a/parser/schema/basic_type_parser.go
+++ b/parser/schema/basic_type_parser.go
@@ -1,10 +1,11 @@
 package schema
 
 import (
+	"strings"
+
 	"github.com/iancoleman/orderedmap"
 	. "github.com/parvez3019/go-swagger3/openApi3Schema"
 	"github.com/parvez3019/go-swagger3/parser/utils"
-	"strings"
 )
 
 func (p *parser) parseBasicTypeSchemaObject(pkgPath string, pkgName string, typeName string) (*SchemaObject, error, bool) {
@@ -45,7 +46,7 @@ func (p *parser) parseArrayType(pkgPath string, pkgName string, typeName string,
 	itemTypeName := typeName[2:]
 	schema, ok := p.KnownIDSchema[utils.GenSchemaObjectID(pkgName, itemTypeName, p.SchemaWithoutPkg)]
 	if ok {
-		schemaObject.Items = &SchemaObject{Ref: utils.AddSchemaRefLinkPrefix(schema.ID)}
+		schemaObject.Items = &SchemaObject{Ref: p.masker.AddSchemaRefLinkPrefix(schema.ID)}
 		return &schemaObject, nil, true
 	}
 	schemaObject.Items, err = p.ParseSchemaObject(pkgPath, pkgName, itemTypeName)
@@ -60,7 +61,7 @@ func (p *parser) parseMapType(pkgPath string, pkgName string, typeName string, s
 	itemTypeName := typeName[5:]
 	schema, ok := p.KnownIDSchema[utils.GenSchemaObjectID(pkgName, itemTypeName, p.SchemaWithoutPkg)]
 	if ok {
-		schemaObject.Items = &SchemaObject{Ref: utils.AddSchemaRefLinkPrefix(schema.ID)}
+		schemaObject.Items = &SchemaObject{Ref: p.masker.AddSchemaRefLinkPrefix(schema.ID)}
 		return &schemaObject, nil, true
 	}
 	schemaProperty, err := p.ParseSchemaObject(pkgPath, pkgName, itemTypeName)

--- a/parser/schema/custom_type_parser.go
+++ b/parser/schema/custom_type_parser.go
@@ -3,14 +3,15 @@ package schema
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/iancoleman/orderedmap"
-	. "github.com/parvez3019/go-swagger3/openApi3Schema"
-	"github.com/parvez3019/go-swagger3/parser/utils"
-	log "github.com/sirupsen/logrus"
 	"go/ast"
 	"reflect"
 	"strconv"
 	"strings"
+
+	"github.com/iancoleman/orderedmap"
+	. "github.com/parvez3019/go-swagger3/openApi3Schema"
+	"github.com/parvez3019/go-swagger3/parser/utils"
+	log "github.com/sirupsen/logrus"
 )
 
 func (p *parser) parseCustomTypeSchemaObject(pkgPath string, pkgName string, typeName string) (*SchemaObject, error) {
@@ -108,7 +109,7 @@ func (p *parser) parseCustomTypeSchemaObject(pkgPath string, pkgName string, typ
 			if err != nil {
 				p.Debugf("ParseSchemaObject parse array items err: %s", err.Error())
 			} else {
-				schemaObject.Items.Ref = utils.AddSchemaRefLinkPrefix(schemaItemsSchemeaObjectID)
+				schemaObject.Items.Ref = p.masker.AddSchemaRefLinkPrefix(schemaItemsSchemeaObjectID)
 			}
 		} else if utils.IsGoTypeOASType(typeAsString) {
 			schemaObject.Items.Type = utils.GoTypesOASTypes[typeAsString]
@@ -125,7 +126,7 @@ func (p *parser) parseCustomTypeSchemaObject(pkgPath string, pkgName string, typ
 			if err != nil {
 				p.Debugf("ParseSchemaObject parse array items err: %s", err.Error())
 			} else {
-				propertySchema.Ref = utils.AddSchemaRefLinkPrefix(schemaItemsSchemeaObjectID)
+				propertySchema.Ref = p.masker.AddSchemaRefLinkPrefix(schemaItemsSchemeaObjectID)
 			}
 		} else if utils.IsGoTypeOASType(typeAsString) {
 			propertySchema.Type = utils.GoTypesOASTypes[typeAsString]
@@ -200,7 +201,7 @@ astFieldsLoop:
 						fieldSchema.Items = schema.Items
 					}
 				}
-				fieldSchema.Ref = utils.AddSchemaRefLinkPrefix(fieldSchemaSchemeaObjectID)
+				fieldSchema.Ref = p.masker.AddSchemaRefLinkPrefix(fieldSchemaSchemeaObjectID)
 			}
 		} else if utils.IsGoTypeOASType(typeAsString) {
 			fieldSchema.Type = utils.GoTypesOASTypes[typeAsString]
@@ -311,7 +312,7 @@ astFieldsLoop:
 			}
 
 			if ref := astFieldTag.Get("$ref"); ref != "" {
-				fieldSchema.Ref = utils.AddSchemaRefLinkPrefix(ref)
+				fieldSchema.Ref = p.masker.AddSchemaRefLinkPrefix(ref)
 				fieldSchema.Type = "" // remove default type in case of reference link
 			}
 
@@ -366,7 +367,7 @@ astFieldsLoop:
 						fieldSchema.Items = schema.Items
 					}
 				}
-				fieldSchema.Ref = utils.AddSchemaRefLinkPrefix(fieldSchemaSchemeaObjectID)
+				fieldSchema.Ref = p.masker.AddSchemaRefLinkPrefix(fieldSchemaSchemeaObjectID)
 			}
 		} else if utils.IsGoTypeOASType(typeAsString) {
 			fieldSchema.Type = utils.GoTypesOASTypes[typeAsString]

--- a/parser/utils/masking.go
+++ b/parser/utils/masking.go
@@ -1,0 +1,29 @@
+package utils
+
+import "strings"
+
+type Masker struct {
+	banStrings []string
+}
+
+func NewMasker(banStrings []string) *Masker {
+	return &Masker{
+		banStrings: banStrings,
+	}
+}
+
+func (m *Masker) sanitizeString(s string) string {
+	for _, bannedStrings := range m.banStrings {
+		s = strings.Replace(s, bannedStrings, "", 1)
+	}
+
+	return s
+}
+
+func (m *Masker) ReplaceBackslash(origin string) string {
+	return ReplaceBackslash(m.sanitizeString(origin))
+}
+
+func (m *Masker) AddSchemaRefLinkPrefix(name string) string {
+	return AddSchemaRefLinkPrefix(m.sanitizeString(name))
+}


### PR DESCRIPTION
Added functionality to get strings from cli and delete them from custom types refs.

e.g. if we have a custom type named `github.com.username.project.name.model.MyStruct` and we pass `github.com.username.project.name.` to CLI's `--hide-refs` option, the Components' object and $refs of that object will be of the form `model.MyStruct`

Added tests.