### PR TITLE
Update instalation instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Generate [OpenAPI Specification](https://swagger.io/specification) json file wit
 ## 1. Install
 
 ```
-go get -u github.com/parvez3019/go-swagger3
+go install github.com/parvez3019/go-swagger3@latest
 ```
 
 


### PR DESCRIPTION
Use `go install` rather than `go get`

Fixes #10

Signed-off-by: Alvaro Frias Garay <alvaro.frias@eclypsium.com>