### PR TITLE
Added anonymous structure support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@
 
 # build file
 go-swagger3
+#Vscode
+.vscode

--- a/parser/gomod/parser.go
+++ b/parser/gomod/parser.go
@@ -1,7 +1,6 @@
 package gomod
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -30,7 +29,7 @@ func NewParser(utils model.Utils) Parser {
 // Parse parse go.mod info
 func (p *parser) Parse() error {
 	log.Info("Parsing GoMod Info ...")
-	b, err := ioutil.ReadFile(p.GoModFilePath)
+	b, err := os.ReadFile(p.GoModFilePath)
 	if err != nil {
 		return err
 	}

--- a/parser/schema/parser.go
+++ b/parser/schema/parser.go
@@ -1,14 +1,15 @@
 package schema
 
 import (
-	. "github.com/parvez3019/go-swagger3/openApi3Schema"
-	"github.com/parvez3019/go-swagger3/parser/model"
-	"github.com/parvez3019/go-swagger3/parser/utils"
 	"go/ast"
 	goParser "go/parser"
 	"go/token"
 	"os"
 	"strings"
+
+	. "github.com/parvez3019/go-swagger3/openApi3Schema"
+	"github.com/parvez3019/go-swagger3/parser/model"
+	"github.com/parvez3019/go-swagger3/parser/utils"
 )
 
 type Parser interface {
@@ -54,6 +55,7 @@ func (p *parser) RegisterType(pkgPath, pkgName, typeName string) (string, error)
 		_, ok := p.OpenAPI.Components.Schemas[utils.ReplaceBackslash(typeName)]
 		if !ok {
 			p.OpenAPI.Components.Schemas[utils.ReplaceBackslash(typeName)] = schemaObject
+			p.OpenAPI.Components.Schemas[schemaObject.ID] = schemaObject
 		}
 		return utils.GenSchemaObjectID(pkgName, typeName, p.SchemaWithoutPkg), nil
 	} else {
@@ -65,6 +67,7 @@ func (p *parser) RegisterType(pkgPath, pkgName, typeName string) (string, error)
 		_, ok := p.OpenAPI.Components.Schemas[utils.ReplaceBackslash(registerTypeName)]
 		if !ok {
 			p.OpenAPI.Components.Schemas[utils.ReplaceBackslash(registerTypeName)] = schemaObject
+			p.OpenAPI.Components.Schemas[schemaObject.ID] = schemaObject
 		}
 	}
 	return registerTypeName, nil


### PR DESCRIPTION
### example
```go
type A struct{
  Page int32 `json:"page"`  // page num
  Page int32 `json:"page_size"`
  Filters struct{
       Status int32 `json:"status"`
  }
}
```
Added anonymous structure support.

# read description from comment 
Page description page num. 
if I use description:"page num",is make the go struct too complicated