### PR TITLE
fix: add missing format and type field

### DIFF
--- a/parser/schema/custom_type_parser.go
+++ b/parser/schema/custom_type_parser.go
@@ -260,6 +260,8 @@ astFieldsLoop:
 					name = v
 				}
 			}
+			p.addType(astFieldTag, fieldSchema)
+			p.addFormat(astFieldTag, fieldSchema)
 			p.addExample(astFieldTag, fieldSchema)
 			p.addOverrideExample(astFieldTag, fieldSchema)
 			p.addRequiredField(astFieldTag, isRequired, structSchema, name)
@@ -367,6 +369,20 @@ astFieldsLoop:
 			}
 			continue
 		}
+	}
+}
+
+func (p *parser) addType(astFieldTag reflect.StructTag, fieldSchema *SchemaObject) {
+	if tag := astFieldTag.Get("type"); tag != "" {
+		fieldSchema.Type = tag
+		fieldSchema.Ref = ""
+		fieldSchema.Items = nil
+	}
+}
+
+func (p *parser) addFormat(astFieldTag reflect.StructTag, fieldSchema *SchemaObject) {
+	if tag := astFieldTag.Get("format"); tag != "" {
+		fieldSchema.Format = tag
 	}
 }
 


### PR DESCRIPTION
Fields `format` and `type` are present in the README.md but not implemented.