### PR TITLE
fix: format on primitive types

### DIFF
--- a/integration_test/test_data/spec/expected.json
+++ b/integration_test/test_data/spec/expected.json
@@ -103,7 +103,6 @@
             "description": "extra field",
             "schema": {
               "type": "string",
-              "format": "string",
               "description": "extra field"
             }
           }
@@ -219,7 +218,6 @@
             "required": true,
             "schema": {
               "type": "string",
-              "format": "string",
               "description": "Use as filter.id! Planogram dbKey [comma separated list]"
             }
           },
@@ -230,7 +228,6 @@
             "required": true,
             "schema": {
               "type": "string",
-              "format": "string",
               "description": "Use as filter.locationId! Location ID"
             }
           },
@@ -240,7 +237,6 @@
             "description": "Includes. Can be: position, fixture, liveFlrFixture",
             "schema": {
               "type": "string",
-              "format": "string",
               "description": "Includes. Can be: position, fixture, liveFlrFixture"
             }
           },
@@ -250,7 +246,6 @@
             "description": "Use as filter.commodity! Commodity",
             "schema": {
               "type": "string",
-              "format": "string",
               "description": "Use as filter.commodity! Commodity"
             }
           },
@@ -260,7 +255,6 @@
             "description": "Use as filter.commodityGroup! Commodity Group",
             "schema": {
               "type": "string",
-              "format": "string",
               "description": "Use as filter.commodityGroup! Commodity Group"
             }
           },
@@ -270,7 +264,6 @@
             "description": "Use as filter.isDigitalScreen! IsDigitalScreen. Can be: true, false",
             "schema": {
               "type": "string",
-              "format": "string",
               "description": "Use as filter.isDigitalScreen! IsDigitalScreen. Can be: true, false"
             }
           }

--- a/integration_test/test_data/spec/expected_with_pkg.json
+++ b/integration_test/test_data/spec/expected_with_pkg.json
@@ -103,7 +103,6 @@
             "description": "extra field",
             "schema": {
               "type": "string",
-              "format": "string",
               "description": "extra field"
             }
           }
@@ -219,7 +218,6 @@
             "required": true,
             "schema": {
               "type": "string",
-              "format": "string",
               "description": "Use as filter.id! Planogram dbKey [comma separated list]"
             }
           },
@@ -230,7 +228,6 @@
             "required": true,
             "schema": {
               "type": "string",
-              "format": "string",
               "description": "Use as filter.locationId! Location ID"
             }
           },
@@ -240,7 +237,6 @@
             "description": "Includes. Can be: position, fixture, liveFlrFixture",
             "schema": {
               "type": "string",
-              "format": "string",
               "description": "Includes. Can be: position, fixture, liveFlrFixture"
             }
           },
@@ -250,7 +246,6 @@
             "description": "Use as filter.commodity! Commodity",
             "schema": {
               "type": "string",
-              "format": "string",
               "description": "Use as filter.commodity! Commodity"
             }
           },
@@ -260,7 +255,6 @@
             "description": "Use as filter.commodityGroup! Commodity Group",
             "schema": {
               "type": "string",
-              "format": "string",
               "description": "Use as filter.commodityGroup! Commodity Group"
             }
           },
@@ -270,7 +264,6 @@
             "description": "Use as filter.isDigitalScreen! IsDigitalScreen. Can be: true, false",
             "schema": {
               "type": "string",
-              "format": "string",
               "description": "Use as filter.isDigitalScreen! IsDigitalScreen. Can be: true, false"
             }
           }

--- a/parser/utils/type_utils.go
+++ b/parser/utils/type_utils.go
@@ -8,7 +8,7 @@ import (
 )
 
 var GoTypesOASFormats = map[string]string{
-	"bool":    "boolean",
+	"bool":    "",
 	"uint":    "int64",
 	"uint8":   "int64",
 	"uint16":  "int64",
@@ -21,7 +21,7 @@ var GoTypesOASFormats = map[string]string{
 	"int64":   "int64",
 	"float32": "float",
 	"float64": "double",
-	"string":  "string",
+	"string":  "",
 	"error":   "error",
 }
 
@@ -128,7 +128,7 @@ func GetModuleNameFromGoMod(path string) string {
 }
 
 func IsInStringList(list []string, s string) bool {
-	for i, _ := range list {
+	for i := range list {
 		if list[i] == s {
 			return true
 		}


### PR DESCRIPTION
`string` and `boolean` aren't valid formats for `string` and `bool` go types. Here is the data type spec https://swagger.io/specification/v3/