### PR TITLE
fix: correctly handle form and file parameters as requestBody instead of query parameters

### DIFF
--- a/parser/operations/param.go
+++ b/parser/operations/param.go
@@ -29,15 +29,19 @@ func (p *parser) parseParamComment(pkgPath, pkgName string, operation *oas.Opera
 
 	goType := getType(re, matches)
 
-	// `file`, `form`
-	appendRequestBody(operation, parameterObject, goType)
+	switch parameterObject.In {
+	// file, form
+	case "form", "file":
+		appendRequestBody(operation, parameterObject, goType)
+		return nil
+	// body
+	case "body":
+		return p.parseRequestBody(pkgPath, pkgName, operation, parameterObject, goType, matches)
 
-	// `path`, `query`, `header`, `cookie`
-	if parameterObject.In != "body" {
+	// path, query, header, cookie
+	default:
 		return p.appendQueryParam(pkgPath, pkgName, operation, parameterObject, goType)
 	}
-
-	return p.parseRequestBody(pkgPath, pkgName, operation, parameterObject, goType, matches)
 }
 
 func (p *parser) parseRequestBody(pkgPath string, pkgName string, operation *oas.OperationObject, parameterObject oas.ParameterObject, goType string, matches []string) error {

--- a/parser/operations/parser_mock_test.go
+++ b/parser/operations/parser_mock_test.go
@@ -1,0 +1,30 @@
+package operations
+
+import (
+	"go/ast"
+
+	"github.com/parvez3019/go-swagger3/openApi3Schema"
+	"github.com/stretchr/testify/mock"
+)
+
+type MockSchemaParser struct {
+	mock.Mock
+}
+
+func (m *MockSchemaParser) GetPkgAst(pkgPath string) (map[string]*ast.Package, error) {
+	args := m.Called(pkgPath)
+	return args.Get(0).(map[string]*ast.Package), args.Error(1)
+}
+
+func (m *MockSchemaParser) RegisterType(pkgPath, pkgName, typeName string) (string, error) {
+	args := m.Called(pkgPath, pkgName, typeName)
+	return args.String(0), args.Error(1)
+}
+
+func (m *MockSchemaParser) ParseSchemaObject(pkgPath, pkgName, typeName string) (*openApi3Schema.SchemaObject, error) {
+	args := m.Called(pkgPath, pkgName, typeName)
+	if obj := args.Get(0); obj != nil {
+		return obj.(*openApi3Schema.SchemaObject), args.Error(1)
+	}
+	return nil, args.Error(1)
+}

--- a/parser/operations/parser_test.go
+++ b/parser/operations/parser_test.go
@@ -2,10 +2,11 @@ package operations
 
 import (
 	"errors"
+	"testing"
+
 	oas "github.com/parvez3019/go-swagger3/openApi3Schema"
 	"github.com/parvez3019/go-swagger3/parser/schema"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func Test_ParseHeader(t *testing.T) {
@@ -50,5 +51,72 @@ func Test_ParseHeader(t *testing.T) {
 			}
 			assert.Equal(t, test.expectedParameters, operationObject.Parameters)
 		})
+	}
+}
+
+func TestParseParamComment_FormParam(t *testing.T) {
+	p := &parser{}
+	op := &oas.OperationObject{}
+
+	comment := "@Param file form ignored true \"Upload file\" \"/path/to/file\""
+
+	err := p.parseParamComment("example/pkg", "pkg", op, comment)
+	if err != nil {
+		t.Fatalf("Expected no error, got: %v", err)
+	}
+	if op.RequestBody == nil {
+		t.Error("Expected RequestBody to be set for form param")
+	}
+}
+
+func TestParseParamComment_BodyParam(t *testing.T) {
+	mockSchema := new(MockSchemaParser)
+
+	p := &parser{
+		Parser: mockSchema,
+	}
+
+	op := &oas.OperationObject{}
+
+	comment := "@Param user body User true \"User info\""
+
+	mockSchema.On("RegisterType", "example/pkg", "pkg", "User").Return("UserSchemaRef", nil)
+
+	err := p.parseParamComment("example/pkg", "pkg", op, comment)
+	if err != nil {
+		t.Fatalf("Expected no error, got: %v", err)
+	}
+
+	if op.RequestBody == nil {
+		t.Error("Expected RequestBody to be set for body param")
+	}
+
+	mockSchema.AssertExpectations(t)
+}
+
+func TestParseParamComment_QueryParam(t *testing.T) {
+	p := &parser{}
+	op := &oas.OperationObject{}
+
+	comment := "@Param id query int true \"User ID\""
+
+	err := p.parseParamComment("example/pkg", "pkg", op, comment)
+	if err != nil {
+		t.Fatalf("Expected no error, got: %v", err)
+	}
+	if len(op.Parameters) == 0 {
+		t.Error("Expected query param to be added to operation.Parameters")
+	}
+}
+
+func TestParseParamComment_InvalidComment(t *testing.T) {
+	p := &parser{}
+	op := &oas.OperationObject{}
+
+	comment := "@Param invalid format only"
+
+	err := p.parseParamComment("pkg", "pkg", op, comment)
+	if err == nil {
+		t.Error("Expected error for invalid comment format, but got none")
 	}
 }


### PR DESCRIPTION
Issue:
When generating OpenAPI specs, parameters with in value form or file were incorrectly treated as query parameters, causing unexpected parameter objects to appear in the output.

Cause:
The original code used an if condition which didn't clearly separate handling of parameters by their location, leading to form and file parameters being processed as query parameters.

Solution:
Refactor the code to use a switch statement on the parameter’s in value to explicitly handle:

- form and file parameters by calling appendRequestBody (adding them to requestBody content as form data),

- body parameters by calling parseRequestBody,

- Other parameters (query, path, etc.) by calling appendQueryParam.